### PR TITLE
Improve type classification of static bodies

### DIFF
--- a/src/solvers/timestepping.jl
+++ b/src/solvers/timestepping.jl
@@ -213,12 +213,14 @@ end
 solvertype(::Problem{<:PsiOmegaFluidGrid{CNAB}}) = SolverPsiOmegaGridCNAB
 
 function prescribe_motion!(state::StatePsiOmegaGridCNAB, solver::SolverPsiOmegaGridCNAB)
-    bodies = solver.prob.bodies
+    prob = solver.prob
+    bodies = prob.bodies
+    fluidframe = prob.fluid.frame
     panels = quantities(state).panels
 
     for (i, (bodypanels, body)) in enumerate(zip(panels.perbody, bodies))
-        if body isa RigidBody && !(body isa RigidBody{DiscretizationFrame})
-            prescribe_motion!(bodypanels, body, state.t)
+        if body isa RigidBody && !is_static(body, fluidframe)
+            prescribe_motion!(bodypanels, fluidframe, body, state.t)
             update!(solver.reg, bodypanels, i)
         end
     end


### PR DESCRIPTION
When checking if a body is static in the fluid discretization, the code now checks if the body's frame is `DiscretizationFrame` or is the same base frame as the fluid's discretization.

Before, the body has to explicitly have the `DiscretizationFrame` if it was to be static in the fluid grid. Now, if both the fluid grid and bodies are in the `GlobalFrame` or any other `BaseFrame`, the bodies will be considered static.